### PR TITLE
Remover flavor text check

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/dead/new_player/new_player.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/dead/new_player/new_player.dm
@@ -127,9 +127,6 @@
 		return TRUE
 
 	if(href_list["lobby_ready"])
-		if(!client.prefs.check_flavor_text())
-			ready = PLAYER_NOT_READY
-			return
 
 		if(SSticker.current_state <= GAME_STATE_PREGAME)
 			client << output(null, "lobbybrowser:imgsrc")
@@ -170,8 +167,6 @@
 		return
 
 	if(href_list["lobby_join"])
-		if(!client.prefs.check_flavor_text())
-			return
 
 		if(!SSticker?.IsRoundInProgress())
 			to_chat(usr, "<span class='boldwarning'>The round is either not ready, or has already finished...</span>")
@@ -201,8 +196,6 @@
 
 
 	if(href_list["SelectedJob"])
-		if(!client.prefs.check_flavor_text())
-			return
 
 		if(!SSticker?.IsRoundInProgress())
 			to_chat(usr, "<span class='danger'>The round is either not ready, or has already finished...</span>")

--- a/modular_skyrat/modules/customization/modules/client/preferences.dm
+++ b/modular_skyrat/modules/customization/modules/client/preferences.dm
@@ -282,9 +282,9 @@ GLOBAL_LIST_INIT(food, list(
 
 #define APPEARANCE_CATEGORY_COLUMN "<td valign='top' width='14%'>"
 #define MAX_MUTANT_ROWS 4
-#define FLAVORTEXT_JOIN_MINIMUM 150
+#define FLAVORTEXT_JOIN_MINIMUM 0
 
-/datum/preferences/proc/check_flavor_text(inform_client = TRUE)
+/*/datum/preferences/proc/check_flavor_text(inform_client = TRUE)
 	if(!features["flavor_text"])
 		if(check_rights(R_ADMIN, FALSE))
 			var/resp = tgui_input_list(usr, "Do you want to bypass the flavor text requirement?", "Confirmation", list("Yes", "No"), 1 MINUTES)
@@ -303,7 +303,7 @@ GLOBAL_LIST_INIT(food, list(
 		if(inform_client)
 			to_chat(parent, "<span class='userdanger'>Your flavor text must be longer than [FLAVORTEXT_JOIN_MINIMUM] characters!</span>")
 		return FALSE
-	return TRUE
+	return TRUE*/
 
 /datum/preferences/proc/ShowChoices(mob/user)
 	if(!user || !user.client)


### PR DESCRIPTION
Muito ruim esse flavor text check em servidores brasileiros. Só atrapalha os novos jogadores que nem sabem onde fica essa porra, muito menos tem paciência para detalhar em cerca de 150 palavras.


