### PR TITLE
Remoção das ambitions V2

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -415,14 +415,7 @@
 
 
 /datum/antagonist/changeling/proc/forge_objectives()
-	//OBJECTIVES - random traitor objectives. Unique objectives "steal brain" and "identity theft".
-	//No escape alone because changelings aren't suited for it and it'd probably just lead to rampant robusting
-	//If it seems like they'd be able to do it in play, add a 10% chance to have to escape alone
 
-
-	objectives += new /datum/objective/ambitions() //SKYRAT EDIT ADDITION - AMBITIONS
-	//SKYRAT EDIT REMOVAL BEGIN - AMBITIONS
-	/*
 	var/escape_objective_possible = TRUE
 
 	switch(competitive_objectives ? rand(1,3) : 1)
@@ -489,9 +482,6 @@
 			identity_theft.find_target()
 			objectives += identity_theft
 		escape_objective_possible = FALSE
-	*/
-	//SKYRAT EDIT REMOVAL END
-
 
 /datum/antagonist/changeling/admin_add(datum/mind/new_owner,mob/admin)
 	. = ..()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -112,36 +112,7 @@
 	for(var/i in objective_count to objective_limit - 1)
 		objectives += forge_single_generic_objective()
 
-
-
-/**
- * ## forge_ending_objective
- *
- * Forges the endgame objective and adds it to this datum's objective list.
- */
 /datum/antagonist/traitor/proc/forge_ending_objective()
-	return
-	/* SKYRAT EDIT  - AMBITIONS
-	if(is_hijacker)
-		ending_objective = new /datum/objective/hijack
-		ending_objective.owner = owner
-		return
-	var/martyr_compatibility = TRUE
-	for(var/datum/objective/traitor_objective in objectives)
-		if(!traitor_objective.martyr_compatible)
-			martyr_compatibility = FALSE
-			break
-		ending_objective = new /datum/objective/martyr
-		ending_objective.owner = owner
-		objectives += ending_objective
-		return
-	ending_objective = new /datum/objective/escape
-	ending_objective.owner = owner
-	objectives += ending_objective
-	*/
-
-/// Forges a single escape objective and adds it to this datum's objective list.
-/datum/antagonist/traitor/proc/forge_escape_objective()
 	var/is_martyr = prob(MARTYR_PROB)
 	var/martyr_compatibility = TRUE
 


### PR DESCRIPTION
Nessa segunda versão, é apenas uma alteração no qual agora irá listar o terceiro objetivo que é o objetivo final.

Objetivos finais ['Escapar vivo', 'Morte gloriosa', 'Hijacking']

Quanto os changelings, finalmente foi feito de forma correta a remoção das ambitions e adição de objetivos. Lembrando que o objetivo de genes agora aparentemente é sempre referente a ter mais genes extraídos do que o outro changeling.

