### PR TITLE
Construção de IPC + research para órgãos de IPC

### DIFF
--- a/nebula_modular/code/modules/servantipcbuild/ipcbuilding.dm
+++ b/nebula_modular/code/modules/servantipcbuild/ipcbuilding.dm
@@ -1,0 +1,165 @@
+/obj/item/mmi/posibrain/CtrlClick(mob/living/user)
+	eject_posi(user)
+	to_chat(user, span_notice("You press the button and release the electronics from the posibrain."))
+
+/obj/item/mmi/posibrain/proc/eject_posi(mob/user)
+	var/obj/item/organ/brain/ipc_positron/roboticsmotherboard/brain = new /obj/item/organ/brain/ipc_positron/roboticsmotherboard
+	brainmob.container = null //Reset brainmob mmi var.
+	brainmob.forceMove(brain) //Throw mob into brain.
+	brainmob.set_stat(DEAD)
+	brainmob.emp_damage = 0
+	brainmob.reset_perspective() //so the brainmob follows the brain organ instead of the mmi. And to update our vision
+	brain.brainmob = brainmob //Set the brain to use the brainmob
+	brainmob = null //Set mmi brainmob var to null
+	brain.forceMove(drop_location())
+	if(Adjacent(user))
+		user.put_in_hands(brain)
+	brain.organ_flags &= ~ORGAN_FROZEN
+	brain = null //No more brain in here
+	qdel(src)
+
+/obj/item/organ/brain/ipc_positron/roboticsmotherboard
+	name = "positronics motherboard"
+	slot = ORGAN_SLOT_BRAIN
+	zone = BODY_ZONE_CHEST
+	status = ORGAN_ROBOTIC
+	organ_flags = ORGAN_SYNTHETIC
+	desc = "A motherboard housing an artificial consciousness, cannot speak unlike the blocky counterpart."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "integrated_circuit"
+
+// ===TECH NODES===
+
+/datum/techweb_node/sapient_synth
+	id = "sapient_synth"
+	display_name = "Sapient synthetic research"
+	description = "Machines with autonomy comparable to that of a living crewmember."
+	prereq_ids = list("adv_robotics")
+	design_ids = list(
+		//"newipc_hollow",
+		"ipccell",
+		"ipccord",
+		"ipceyes",
+		"ipcears",
+		"ipcvoice",
+		"ipclungs",
+		"ipcheart",
+		"ipcliver"
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
+
+/datum/design/newipc_hollow
+	name = "I.P.C hollow shell"
+	id = "newipc_hollow"
+	build_type = MECHFAB
+	build_path = /obj/item/ipc_deployer
+	materials = list(/datum/material/iron=15000, /datum/material/gold=10000, /datum/material/silver=4000, /datum/material/glass=2000, )
+	construction_time = 500
+	category = list("Cybernetics")
+
+/datum/design/ipccell
+	name = "I.P.C power cell"
+	id = "ipccell"
+	build_type = MECHFAB
+	build_path = /obj/item/organ/stomach/robot_ipc
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	construction_time = 150
+	category = list("Cybernetics")
+
+/datum/design/ipccord
+	name = "I.P.C power cord"
+	id = "ipccord"
+	build_type = MECHFAB
+	build_path = /obj/item/organ/cyberimp/arm/power_cord
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	construction_time = 150
+	category = list("Cybernetics")
+
+/datum/design/ipceyes
+	name = "I.P.C eyes"
+	id = "ipceyes"
+	build_type = MECHFAB
+	build_path = /obj/item/organ/eyes/robot_ipc
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	construction_time = 150
+	category = list("Cybernetics")
+
+/datum/design/ipcears
+	name = "I.P.C auditory sensors"
+	id = "ipcears"
+	build_type = MECHFAB
+	build_path = /obj/item/organ/ears/robot_ipc
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	construction_time = 150
+	category = list("Cybernetics")
+
+/datum/design/ipcvoice
+	name = "robotic voicebox"
+	id = "ipcvoice"
+	build_type = MECHFAB
+	build_path = /obj/item/organ/tongue/robot_ipc
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	construction_time = 150
+	category = list("Cybernetics")
+
+/datum/design/ipclungs
+	name = "I.P.C heatsink"
+	id = "ipclungs"
+	build_type = MECHFAB
+	build_path = /obj/item/organ/lungs/robot_ipc
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	construction_time = 150
+	category = list("Cybernetics")
+
+/datum/design/ipcheart
+	name = "I.P.C hydraulic pump"
+	id = "ipcheart"
+	build_type = MECHFAB
+	build_path = /obj/item/organ/heart/robot_ipc
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	construction_time = 150
+	category = list("Cybernetics")
+
+/datum/design/ipcliver
+	name = "I.P.C reagent unit"
+	id = "ipcliver"
+	build_type = MECHFAB
+	build_path = /obj/item/organ/liver/robot_ipc
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	construction_time = 150
+	category = list("Cybernetics")
+
+// ===IPC PARTS===
+
+/obj/item/ipc_deployer
+	name = "I.P.C shell deployer"
+	desc = "A kit that contains everything needed to deploy a new and hollow I.P.C shell."
+	icon = 'icons/mob/augmentation/augments.dmi'
+	icon_state = "robo_suit"
+
+// ===IPC DEPLOYMENT===
+///obj/item/ipc_deployer/AltClick(mob/living/user)
+/obj/item/bodypart/chest/robot/AltClick(mob/living/user)
+	var/mob/living/carbon/human/species/ipc/newipc = new /mob/living/carbon/human/species/ipc
+	newipc.forceMove(drop_location())
+	qdel(newipc.getorganslot(ORGAN_SLOT_BRAIN))
+	qdel(newipc.getorganslot(ORGAN_SLOT_EYES))
+	qdel(newipc.getorganslot(ORGAN_SLOT_EARS))
+	qdel(newipc.getorganslot(ORGAN_SLOT_TONGUE))
+	qdel(newipc.getorganslot(ORGAN_SLOT_LIVER))
+	qdel(newipc.getorganslot(ORGAN_SLOT_HEART))
+	qdel(newipc.getorganslot(ORGAN_SLOT_LUNGS))
+	qdel(newipc.getorganslot(ORGAN_SLOT_STOMACH))
+	qdel(newipc.getorganslot(ORGAN_SLOT_LEFT_ARM_AUG))
+	qdel(newipc.get_bodypart(BODY_ZONE_L_ARM))
+	qdel(newipc.get_bodypart(BODY_ZONE_R_ARM))
+	qdel(newipc.get_bodypart(BODY_ZONE_L_LEG))
+	qdel(newipc.get_bodypart(BODY_ZONE_R_LEG))
+	qdel(newipc.get_bodypart(BODY_ZONE_HEAD))
+	newipc.update_body()
+	qdel(src)
+///obj/item/ipc_deployer/examine(mob/user)
+/*
+/obj/item/bodypart/chest/robot/examine(mob/user)
+	to_chat(user, span_boldnotice("Alt-click to deploy the torso as an I.P.C base, the base initially contains no organs, limbs or brain, those you will have to put in yourself."))
+*/

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4800,5 +4800,6 @@
 #include "nebula_modular\code\modules\objects\items\implants\implant_deathalarm.dm"
 #include "nebula_modular\code\modules\projectiles\guns\energy\kinetic_accelerator.dm"
 #include "nebula_modular\code\modules\research\designs\nebula_designs.dm"
+#include "nebula_modular\code\modules\servantipcbuild\ipcbuilding.dm"
 #include "nebula_modular\modules\patreonload.dm"
 // END_INCLUDE


### PR DESCRIPTION
## Sobre o pull request:
Esse PR adiciona construção de IPC ao game, permitindo que roboticistas possam construir IPC's direto na robótica com autonomia completa.

Primeiramente, tudo começa com um posibrain que esteja com um jogador, em sua mão o roboticista sortudo poderá apertar Ctrl e clicar, assim tornando o posibrain em uma mera placa mãe do player, isso age como um cérebro humano normal não podendo falar, todavia é inserido no peito.

Passo 1, obtenha um posibrain:
![image](https://user-images.githubusercontent.com/23427245/131589159-677e4838-ebf0-4a80-b287-f8bf80c00a9b.png)

Passo 2, dê Ctrl+Click no mesmo e o transforme na positronics motherboard:
![image](https://user-images.githubusercontent.com/23427245/131589230-31d71cac-e5fb-4fed-b711-45ca89718077.png)
_(Sim eu tô usando sprite de circuit, não quero ouvir um piu sobre isso)_

Se o jogador decidir que se arrependeu dessa decisão, o cérebro pode ser re-inserido num MMI e colocado num borg, já que isso também funciona.

![image](https://user-images.githubusercontent.com/23427245/131589335-f25f22b2-3b7e-4872-9510-cde556769328.png)

E agora, como que você arranja um corpo de I.P.C?
Bem simples, **você** constrói o mesmo na mão!

Ao pegar um torso de borg e apertar Alt + click nele, você o colocará no chão como um torso de I.P.C **vazio**, possuindo nenhum órgão ou limb, para os limbs você pode colocar peça por peça com os de ciborgue.

![image](https://user-images.githubusercontent.com/23427245/131589553-dea944ac-e4d4-462d-b0c8-935fb0b592bb.png)

![image](https://user-images.githubusercontent.com/23427245/131589584-8a6c4fcd-12d2-467b-89bb-6e29a2d10b5a.png)

Os órgãos são desbloqueados com a research de **_sapient synthetic_**, desbloqueando tudo dos I.P.C's, como o arm cord implant e a power cell, além dos demais órgãos.

![image](https://user-images.githubusercontent.com/23427245/131589016-2977b5e2-9005-4aa3-8cbd-c08137d29795.png)

![image](https://user-images.githubusercontent.com/23427245/131589609-8bbf2064-6816-4ebb-81d6-5418ebba1e86.png)

Lhes vejo in-game, roboticistas!

## Porque isso é bom pro jogo?

Jogadores podem morrer de formas diversas e frequentes, em lugares que jamais serão encontrados, essa update pode ajudar a manter o jogador no jogo, já que ele será basicamente um IPC completamente normal e jogável, como miners por exemplo que podem acabar morrendo na lavaland e trancando a sci sem recurso, agora se um miner morrer ele pode ser levado de volta para a lavaland num corpo morto, para continuar jogando da forma que prefere, como um carbon.

## Changelog
:cl:
add: Sapient synthetic research node
add: You can make hollow I.P.C shells from cyborg torso's
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
